### PR TITLE
Add support for hook path prefixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ From now on your script will be executed every time you deploy the app.
     -----> Running pre-deploy hooks
     -----> deploy/pre-deploy found. Running it ...
 
+In case the scripts are not located in `/deploy` directory, `DOKKU_DEPLOY_HOOKS_PREFIX` env variable can be set. For example, with `DOKKU_DEPLOY_HOOKS_PREFIX` set to `/app`, scripts `/app/deploy/pre-deploy` and `/app/deploy/post-deploy` will be attempted.
+
 MIT License
 ===========
 

--- a/post-deploy
+++ b/post-deploy
@@ -3,7 +3,7 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
-HOOKS_PATH="deploy/post-deploy"
+HOOKS_PATH="${DOKKU_DEPLOY_HOOKS_PREFIX}/deploy/post-deploy"
 
 echo "-----> Running post-deploy hooks"
 . $(dirname "$0")/functions

--- a/pre-deploy
+++ b/pre-deploy
@@ -3,7 +3,7 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
-HOOKS_PATH="deploy/pre-deploy"
+HOOKS_PATH="${DOKKU_DEPLOY_HOOKS_PREFIX}/deploy/pre-deploy"
 
 echo "-----> Running pre-deploy hooks"
 . $(dirname "$0")/functions


### PR DESCRIPTION
I am using a [buildpack](https://github.com/heroku/heroku-buildpack-ruby) that places the repository content in `/app` directory within the container - the hooks look for files in `/deploy` directory.

With this change, I can set `DOKKU_DEPLOY_HOOKS_PREFIX=/app`, and have it invoke `/app/deploy/pre-deploy` / `/app/deploy/post-deploy` scripts.
