### PR TITLE
Deploy path prefix: use per-app config values

### DIFF
--- a/post-deploy
+++ b/post-deploy
@@ -3,6 +3,8 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
+
+DOKKU_DEPLOY_HOOKS_PREFIX=$(dokku config:get $APP DOKKU_DEPLOY_HOOKS_PREFIX || true)
 HOOKS_PATH="${DOKKU_DEPLOY_HOOKS_PREFIX}/deploy/post-deploy"
 
 echo "-----> Running post-deploy hooks"

--- a/pre-deploy
+++ b/pre-deploy
@@ -3,6 +3,8 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
+
+DOKKU_DEPLOY_HOOKS_PREFIX=$(dokku config:get $APP DOKKU_DEPLOY_HOOKS_PREFIX || true)
 HOOKS_PATH="${DOKKU_DEPLOY_HOOKS_PREFIX}/deploy/pre-deploy"
 
 echo "-----> Running pre-deploy hooks"


### PR DESCRIPTION
I made https://github.com/mlomnicki/dokku-deploy-hooks/pull/5 in a hurry and without properly testing - turns out that it was not the right way to access app config variables :(

Changed to use `dokku config:get`.
