### PR TITLE
Use `dokku run` to test for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ From now on your script will be executed every time you deploy the app.
     -----> Running pre-deploy hooks
     -----> deploy/pre-deploy found. Running it ...
 
-In case the scripts are not located in `/deploy` directory, `DOKKU_DEPLOY_HOOKS_PREFIX` env variable can be set. For example, with `DOKKU_DEPLOY_HOOKS_PREFIX` set to `/app`, scripts `/app/deploy/pre-deploy` and `/app/deploy/post-deploy` will be attempted.
-
 MIT License
 ===========
 

--- a/functions
+++ b/functions
@@ -3,15 +3,13 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
-IMAGE="dokku/$APP"
 
 function execute_hooks() {
   local hooks_path="$1"
 
   echo $hooks_path
 
-  id=$(docker run -d $IMAGE test -f $hooks_path)
-  if [ $(docker wait $id) -ne 0 ]; then
+  if [ $(dokku run $APP test -f $hooks_path) -ne 0 ]; then
     echo "       $hooks_path not found or executable bit not set. Skipping ..."
     exit 0
   fi

--- a/functions
+++ b/functions
@@ -9,7 +9,7 @@ function execute_hooks() {
 
   echo $hooks_path
 
-  if [ $(dokku run $APP test -f $hooks_path) -ne 0 ]; then
+  if ! dokku run $APP test -f $hooks_path; then
     echo "       $hooks_path not found or executable bit not set. Skipping ..."
     exit 0
   fi

--- a/post-deploy
+++ b/post-deploy
@@ -4,8 +4,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
 
-DOKKU_DEPLOY_HOOKS_PREFIX=$(dokku config:get $APP DOKKU_DEPLOY_HOOKS_PREFIX || true)
-HOOKS_PATH="${DOKKU_DEPLOY_HOOKS_PREFIX}/deploy/post-deploy"
+HOOKS_PATH="deploy/post-deploy"
 
 echo "-----> Running post-deploy hooks"
 . $(dirname "$0")/functions

--- a/pre-deploy
+++ b/pre-deploy
@@ -4,8 +4,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
 
-DOKKU_DEPLOY_HOOKS_PREFIX=$(dokku config:get $APP DOKKU_DEPLOY_HOOKS_PREFIX || true)
-HOOKS_PATH="${DOKKU_DEPLOY_HOOKS_PREFIX}/deploy/pre-deploy"
+HOOKS_PATH="deploy/post-deploy"
 
 echo "-----> Running pre-deploy hooks"
 . $(dirname "$0")/functions

--- a/pre-deploy
+++ b/pre-deploy
@@ -4,7 +4,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
 
-HOOKS_PATH="deploy/post-deploy"
+HOOKS_PATH="deploy/pre-deploy"
 
 echo "-----> Running pre-deploy hooks"
 . $(dirname "$0")/functions


### PR DESCRIPTION
Fixes #4 

This solves my original intent behind `DOKKU_DEPLOY_HOOKS_PREFIX` in much cleaner way. `dokku run` works in the `WORKDIR` that set to app directory by buildpacks/custom Dockerfiles.

Props to @ebeigarts for the idea.
