### PR TITLE
Readme.md - Update Git Clone Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation
 ============
 
     cd /var/lib/dokku/plugins
-    git clone https://github.com/mlomnicki dokku-deploy-hooks deploy-hooks
+    git clone https://github.com/mlomnicki/dokku-deploy-hooks deploy-hooks
 
 Usage
 =====


### PR DESCRIPTION
Git clone command, when copied and pasted as-is throws a Too Many Arguments error. This fixes that error
